### PR TITLE
Added test to check if minimal version CMake can process CMake scripts without errors

### DIFF
--- a/.github/workflows/cmake_test.yml
+++ b/.github/workflows/cmake_test.yml
@@ -1,0 +1,48 @@
+name: "CMake tests"
+
+on: [push, pull_request]
+
+jobs:
+  cmake-3-1:
+    runs-on: ubuntu-18.04
+    strategy:
+      fail-fast: false
+      matrix:
+        cxx: [g++-10]
+        build_type: [Release]
+        std: [11]
+        cmake_version: [3.8.0]
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Install specific CMake
+      env:
+        CMAKE_VERSION: ${{matrix.cmake_version}}
+        CMAKE_INSTALL_FILE: cmake-${{matrix.cmake_version}}-Linux-x86_64.sh
+      run: |
+        wget --no-clobber https://github.com/Kitware/CMake/releases/download/v${{env.CMAKE_VERSION}}/${{env.CMAKE_INSTALL_FILE}}
+        chmod 775 ./${{env.CMAKE_INSTALL_FILE}}
+        sudo ./${{env.CMAKE_INSTALL_FILE}} --skip-license --prefix=/usr/local
+        rm -f ./${{env.CMAKE_INSTALL_FILE}}
+    - name: Create Build Environment
+      run: |
+        ${{matrix.install}}
+        cmake -E make_directory ${{runner.workspace}}/build
+    - name: Configure
+      working-directory: ${{runner.workspace}}/build
+      env:
+        CXX: ${{matrix.cxx}}
+      run: |
+        cmake --warn-uninitialized \
+              -D CMAKE_BUILD_TYPE=${{matrix.build_type}} \
+              -D CMAKE_CXX_STANDARD=${{matrix.std}} \
+              -D UREACT_PEDANTIC:BOOL=y \
+              -D UREACT_WERROR:BOOL=y \
+              $GITHUB_WORKSPACE
+    - name: Build
+      working-directory: ${{runner.workspace}}/build
+      run: cmake --build . --config ${{matrix.build_type}}
+    - name: Test
+      working-directory: ${{runner.workspace}}/build
+      run: ctest -j 10 -C ${{matrix.build_type}} --output-on-failure

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.8)
 
 ################################################################################
 ## UREACT

--- a/doc/integration.md
+++ b/doc/integration.md
@@ -26,7 +26,7 @@ You can use the `ureact::ureact` interface target in CMake.  This target populat
 **µReact** is easiest to use as a single file inside your own repository. Then the following minimal example will work:
 
 ```cmake
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.8)
 project(cmake_test VERSION 0.0.1 LANGUAGES CXX)
 
 # Prepare ureact for other targets to use

--- a/tests/src/CMakeLists.txt
+++ b/tests/src/CMakeLists.txt
@@ -1,18 +1,15 @@
-add_executable(ureact_test)
-
-target_sources(
+add_executable(
     ureact_test
-    PRIVATE
-        main.cpp
-        examples/signal_examples.cpp
-        examples/complex_signal_examples.cpp
-        examples/composition_examples.cpp
-        examples/observer_examples.cpp
-        details/move_test.cpp
-        details/observer_test.cpp
-        details/signal_test.cpp
-        details/operators_test.cpp
-        details/dynamic_signals_test.cpp
+    main.cpp
+    examples/signal_examples.cpp
+    examples/complex_signal_examples.cpp
+    examples/composition_examples.cpp
+    examples/observer_examples.cpp
+    details/move_test.cpp
+    details/observer_test.cpp
+    details/signal_test.cpp
+    details/operators_test.cpp
+    details/dynamic_signals_test.cpp
 )
 
 target_include_directories(ureact_test PRIVATE include)

--- a/tests/src/playground/CMakeLists.txt
+++ b/tests/src/playground/CMakeLists.txt
@@ -1,6 +1,4 @@
-add_executable(ureact_playground)
-
-target_sources(ureact_playground PRIVATE main.cpp)
+add_executable(ureact_playground main.cpp)
 
 target_link_libraries(ureact_playground PRIVATE ureact::ureact)
 


### PR DESCRIPTION
<!--
Please read the contribution guidelines before submitting a pull request:
https://github.com/YarikTH/ureact/blob/master/CONTRIBUTING.md.
By submitting this pull request, you agree that your contributions are licensed
under the µReact license, and agree to future changes to the licensing.
-->

## Description
<!--
Describe the what and the why of your pull request.
-->
Currently, CMake scripts (both CMakeLists.txt and *.cmake) set some version in cmake_minimum_required, but on CI these scripts are executed on arbitrary cmake versions. As a result, if we try to execute cmake scripts on exactly the minimal cmake version, then there are no guarantees that it works. Need to add automatic tests on GitHub actions that will ensure that all is fine.

The Minimal CMake version is changed to 3.8 because `cxx_std_11` compile feature was introduced there. CMake without this feature would be much worse.

## GitHub Issues
<!-- 
If this PR was motivated by some existing issues, reference them here.

If it is a simple bug-fix, please also add a line like 'Closes #123'
to your commit message, so that it is automatically closed.
If it is not, don't, as it might take several iterations for a feature
to be done properly. If in doubt, leave it open and reference it in the
PR itself, so that maintainers can decide.
-->
Closes #40 