### PR TITLE
Remove bitwise operators overloads for signals

### DIFF
--- a/include/ureact/ureact.hpp
+++ b/include/ureact/ureact.hpp
@@ -2138,7 +2138,6 @@ auto binary_operator_impl( left_val_in_t&& lhs, detail::temp_signal<right_val_t,
 UREACT_DECLARE_UNARY_OPERATOR( +, unary_plus )
 UREACT_DECLARE_UNARY_OPERATOR( -, unary_minus )
 UREACT_DECLARE_UNARY_OPERATOR( !, logical_negation )
-UREACT_DECLARE_UNARY_OPERATOR( ~, bitwise_complement )
 
 UREACT_DECLARE_BINARY_OPERATOR( +, addition )
 UREACT_DECLARE_BINARY_OPERATOR( -, subtraction )
@@ -2155,12 +2154,6 @@ UREACT_DECLARE_BINARY_OPERATOR( >=, greater_equal )
 
 UREACT_DECLARE_BINARY_OPERATOR( &&, logical_and )
 UREACT_DECLARE_BINARY_OPERATOR( ||, logical_or )
-
-UREACT_DECLARE_BINARY_OPERATOR( &, bitwise_and )
-UREACT_DECLARE_BINARY_OPERATOR( |, bitwise_or )
-UREACT_DECLARE_BINARY_OPERATOR( ^, bitwise_xor )
-UREACT_DECLARE_BINARY_OPERATOR( <<, bitwise_left_shift )
-UREACT_DECLARE_BINARY_OPERATOR( >>, bitwise_right_shift )
 
 #    if defined( __clang__ ) && defined( __clang_minor__ )
 #        pragma clang diagnostic pop

--- a/tests/src/details/operators_test.cpp
+++ b/tests/src/details/operators_test.cpp
@@ -230,11 +230,9 @@ TEST_SUITE( "operators" )
         auto unary_plus           = +v1;
         auto unary_minus          = -v1;
         auto logical_negation     = !v1;
-        auto bitwise_complement   = ~v1;
         auto unary_plus_2         = +(+v1);
         auto unary_minus_2        = -(+v1);
         auto logical_negation_2   = !(+v1);
-        auto bitwise_complement_2 = ~(+v1);
         // clang-format on
 
         auto checkValues = [&]( std::initializer_list<int> valuesToTest ) {
@@ -246,11 +244,9 @@ TEST_SUITE( "operators" )
                 CHECK( unary_plus.value()           == (+value) );
                 CHECK( unary_minus.value()          == (-value) );
                 CHECK( logical_negation.value()     == (!value) );
-                CHECK( bitwise_complement.value()   == (~value) );
                 CHECK( unary_plus_2.value()         == (+value) );
                 CHECK( unary_minus_2.value()        == (-value) );
                 CHECK( logical_negation_2.value()   == (!value) );
-                CHECK( bitwise_complement_2.value() == (~value) );
                 // clang-format on
             }
         };
@@ -269,11 +265,6 @@ TEST_SUITE( "operators" )
         auto addition            = lhs +  rhs;
         auto subtraction         = lhs -  rhs;
         auto multiplication      = lhs *  rhs;
-        auto bitwise_and         = lhs &  rhs;
-        auto bitwise_or          = lhs |  rhs;
-        auto bitwise_xor         = lhs ^  rhs;
-        auto bitwise_left_shift  = lhs << rhs;
-        auto bitwise_right_shift = lhs >> rhs;
         auto equal               = lhs == rhs;
         auto not_equal           = lhs != rhs;
         auto less                = lhs <  rhs;
@@ -319,11 +310,6 @@ TEST_SUITE( "operators" )
                 CHECK( greater_equal.value()       == (left >= right) );
                 CHECK( logical_and.value()         == (left && right) );
                 CHECK( logical_or.value()          == (left || right) );
-                CHECK( bitwise_and.value()         == (left &  right) );
-                CHECK( bitwise_or.value()          == (left |  right) );
-                CHECK( bitwise_xor.value()         == (left ^  right) );
-                CHECK( bitwise_left_shift.value()  == (left << right) );
-                CHECK( bitwise_right_shift.value() == (left >> right) );
                 // clang-format on
             }
         }
@@ -392,14 +378,10 @@ TEST_SUITE( "operators" )
         //     ! ~            Logical NOT and bitwise NOT
         // 5.  a*b  a/b  a%b  Multiplication, division, and remainder
         // 6.  a+b  a-b       Addition and subtraction
-        // 7.  <<  >>         Bitwise left shift and right shift
         // 8.  <=>            Three-way comparison operator (since C++20)
         // 9.  <  <=          For relational operators < and ≤ respectively
         //     >  >=          For relational operators > and ≥ respectively
         // 10. ==  !=         For equality operators = and ≠ respectively
-        // 11. &              Bitwise AND
-        // 12. ^              Bitwise XOR (exclusive or)
-        // 13. |              Bitwise OR (inclusive or)
         // 14. &&             Logical AND
         // 15. ||             Logical OR
 


### PR DESCRIPTION
## Description
See #72 

## GitHub Issues
<!-- 
If this PR was motivated by some existing issues, reference them here.

If it is a simple bug-fix, please also add a line like 'Closes #123'
to your commit message, so that it is automatically closed.
If it is not, don't, as it might take several iterations for a feature
to be done properly. If in doubt, leave it open and reference it in the
PR itself, so that maintainers can decide.
-->

Closes #72 