### PR TITLE
Remove deprecated operator ->*

### DIFF
--- a/doc/reference.md
+++ b/doc/reference.md
@@ -149,13 +149,6 @@ auto operator|( const signal_t<value_t>& arg, F&& func ) -> detail::temp_signal<
 auto operator|( const signal_pack<values_t...>& arg_pack, F&& func ) -> detail::temp_signal<S, op_t>;
 ```
 
-Deprecated operator overload to construct signals
-
-```cpp
-auto operator->*( const signal_t<value_t>& arg, F&& func ) -> detail::temp_signal<S, op_t>;
-auto operator->*( const signal_pack<values_t...>& arg_pack, F&& func ) -> detail::temp_signal<S, op_t>;
-```
-
 Unary operator overloads to create signals from expressions
 
 ```cpp

--- a/include/ureact/ureact.hpp
+++ b/include/ureact/ureact.hpp
@@ -2285,25 +2285,6 @@ UREACT_WARN_UNUSED_RESULT auto operator|( const signal_pack<values_t...>& arg_pa
 }
 
 
-/// operator->* overload to connect a signal to a function and return the resulting signal.
-/// Deprecated. Use operator| instead.
-template <typename F, typename T, class = typename std::enable_if<is_signal<T>::value>::type>
-UREACT_DEPRECATED UREACT_WARN_UNUSED_RESULT auto operator->*( const T& arg, F&& func )
-    -> decltype( arg | func )
-{
-    return arg | func;
-}
-
-/// operator->* overload to connect multiple signals to a function and return the resulting signal.
-/// Deprecated. Use operator| instead.
-template <typename F, typename... values_t>
-UREACT_DEPRECATED UREACT_WARN_UNUSED_RESULT auto operator->*(
-    const signal_pack<values_t...>& arg_pack, F&& func ) -> decltype( arg_pack | func )
-{
-    return arg_pack | func;
-}
-
-
 template <typename inner_value_t>
 UREACT_WARN_UNUSED_RESULT auto flatten( const signal<signal<inner_value_t>>& outer )
     -> signal<inner_value_t>


### PR DESCRIPTION
<!--
Please read the contribution guidelines before submitting a pull request:
https://github.com/YarikTH/ureact/blob/master/CONTRIBUTING.md.
By submitting this pull request, you agree that your contributions are licensed
under the µReact license, and agree to future changes to the licensing.
-->

## Description
<!--
Describe the what and the why of your pull request.
-->
Remove operator ->* deprecated in 0.3.0, because breaking changes are planned for 0.4.0 anyway.
